### PR TITLE
OPS-3973 Fix EDTF level 2 conformity

### DIFF
--- a/meemoo_sip_validator/v2_1/_core/descriptive/dc_schema.py
+++ b/meemoo_sip_validator/v2_1/_core/descriptive/dc_schema.py
@@ -1,14 +1,17 @@
-from functools import reduce
-from typing import Any, cast
 from collections.abc import Iterable
+from functools import reduce
 from pathlib import Path
+from typing import Any, cast
 
-from edtf_validate.valid_edtf import conformsLevel0, conformsLevel1  # pyright: ignore[reportMissingTypeStubs, reportUnknownVariableType]
+from edtf_validate.valid_edtf import (  # pyright: ignore[reportMissingTypeStubs]
+    conformsLevel0,  # pyright: ignore[reportUnknownVariableType]
+    conformsLevel1,  # pyright: ignore[reportUnknownVariableType]
+)
 
-from ..report import RuleResult, Report, Failure, Severity, TupleWithSource
-from ..models import DCPlusSchema, EDTF
-from ..codes import Code
 from .. import thesauri
+from ..codes import Code
+from ..models import EDTF, DCPlusSchema
+from ..report import Failure, Report, RuleResult, Severity, TupleWithSource
 
 
 def is_valid_mediahaven_edtf(edtf: EDTF) -> bool:
@@ -18,7 +21,7 @@ def is_valid_mediahaven_edtf(edtf: EDTF) -> bool:
         case "{http://id.loc.gov/datatypes/edtf/}EDTF-level1":
             return conformsLevel1(edtf.text)  # pyright: ignore[reportUnknownVariableType]
         case "{http://id.loc.gov/datatypes/edtf/}EDTF-level2":
-            return edtf.text == "XXXX-XX-XX"
+            return edtf.text == "XXXX-XX-XX" or conformsLevel1(edtf.text)  # pyright: ignore[reportUnknownVariableType]
 
 
 def check_edtf_values(dc_schema: DCPlusSchema) -> RuleResult[EDTF]:

--- a/tests/v2_1/test_edtf.py
+++ b/tests/v2_1/test_edtf.py
@@ -1,0 +1,16 @@
+import pytest
+from eark_models.dc_schema.v2_1 import EDTF  # pyright: ignore[reportMissingTypeStubs]
+
+from meemoo_sip_validator.v2_1._core.descriptive.dc_schema import (
+    is_valid_mediahaven_edtf,
+)
+
+
+@pytest.mark.parametrize("edtf_value", ["2026-02-24T11:21:02Z", "1984?", "XXXX-XX-XX"])
+def test_is_valid_mediahaven_edtf_level2(edtf_value: str):
+    edtf = EDTF(
+        __source__="xml",
+        xsi_type="{http://id.loc.gov/datatypes/edtf/}EDTF-level2",
+        text=edtf_value,
+    )
+    assert is_valid_mediahaven_edtf(edtf)


### PR DESCRIPTION
EDTF-fields that are level 2 should also allow values that are conform with level 1 and, by extension, with level 0.

Also, autoformat `dc_schema.py` with ruff.